### PR TITLE
Add drop-down transition for some elements

### DIFF
--- a/src/components/DateToEpoch/TimezoneSelect.tsx
+++ b/src/components/DateToEpoch/TimezoneSelect.tsx
@@ -28,7 +28,7 @@ export default function TimezoneSelect({
   return (
     <div ref={ref} className="relative bg-gray-900 text-gray-100">
       <button
-        className="group flex w-[4.4rem] cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+        className="group flex w-[5rem] cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
         onClick={() => {
           setOpen(!open);
         }}

--- a/src/components/DateToEpoch/TimezoneSelect.tsx
+++ b/src/components/DateToEpoch/TimezoneSelect.tsx
@@ -28,7 +28,7 @@ export default function TimezoneSelect({
   return (
     <div ref={ref} className="relative bg-gray-900 text-gray-100">
       <button
-        className="flex w-[4.4rem] cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+        className="group flex w-[4.4rem] cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
         onClick={() => {
           setOpen(!open);
         }}
@@ -38,14 +38,18 @@ export default function TimezoneSelect({
         </span>
 
         <span>
-          <ChevronDownIcon className={`h-3 w-3 ${open ? 'rotate-180' : ''}`} />
+          <ChevronDownIcon
+            className={`h-5 w-5 rounded-full bg-gray-700 p-1 transition-[colors,transform] group-hover:bg-gray-500 dark:bg-gray-900 dark:group-hover:bg-gray-800 ${
+              open ? 'rotate-180' : ''
+            }`}
+          />
         </span>
       </button>
 
       <ul
         aria-hidden={open ? 'false' : 'true'}
-        className={`absolute top-[110%] bg-gray-900 px-1 py-2 dark:bg-gray-700 ${
-          open ? 'flex flex-col gap-2' : 'hidden'
+        className={`absolute top-[110%] flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
+          open ? 'top-[120%] opacity-100' : 'top-[110%] opacity-0'
         }`}
       >
         {timezoneOptions.map((option, index) => {

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -62,8 +62,8 @@ export const InstancesAmountSelect = ({
 
         <ul
           aria-hidden={!open}
-          className={`absolute top-[110%] bg-gray-900 px-1 py-2 dark:bg-gray-700 ${
-            open ? 'flex flex-col gap-2' : 'hidden'
+          className={`absolute flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
+            open ? 'top-[120%] opacity-100' : 'top-[110%] opacity-0'
           }`}
         >
           {options.map((option, index) => {

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -42,7 +42,7 @@ export const InstancesAmountSelect = ({
         className="relative bg-gray-900 text-gray-100"
       >
         <button
-          className="group flex w-12 cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+          className="group flex max-w-[4rem] cursor-pointer items-center justify-between gap-2 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
           onClick={() => {
             setOpen(!open);
           }}

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -61,7 +61,7 @@ export const InstancesAmountSelect = ({
         </button>
 
         <ul
-          aria-hidden={open ? 'false' : 'true'}
+          aria-hidden={!open}
           className={`absolute top-[110%] bg-gray-900 px-1 py-2 dark:bg-gray-700 ${
             open ? 'flex flex-col gap-2' : 'hidden'
           }`}

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -42,7 +42,7 @@ export const InstancesAmountSelect = ({
         className="relative bg-gray-900 text-gray-100"
       >
         <button
-          className="flex w-12 cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+          className="group flex w-12 cursor-pointer items-center justify-between gap-1 px-2 py-1 transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
           onClick={() => {
             setOpen(!open);
           }}
@@ -53,7 +53,9 @@ export const InstancesAmountSelect = ({
 
           <span>
             <ChevronDownIcon
-              className={`h-3 w-3 ${open ? 'rotate-180' : ''}`}
+              className={`h-5 w-5 rounded-full bg-gray-700 p-1 transition-[colors,transform] group-hover:bg-gray-500 dark:bg-gray-900 dark:group-hover:bg-gray-800 ${
+                open ? 'rotate-180' : ''
+              }`}
             />
           </span>
         </button>

--- a/src/components/ThemeButton.tsx
+++ b/src/components/ThemeButton.tsx
@@ -75,8 +75,8 @@ export default function ThemeButton() {
       <ul
         aria-hidden={open ? 'false' : 'true'}
         className={`${
-          open ? 'block' : 'hidden'
-        } absolute top-[115%] flex flex-col gap-1 rounded bg-gray-100 p-1 shadow-lg dark:bg-gray-700`}
+          open ? 'top-[120%] opacity-100' : 'top-[110%] opacity-0'
+        } absolute flex flex-col gap-1 rounded bg-gray-100 p-1 shadow-lg transition-[top,opacity] dark:bg-gray-700`}
       >
         {themeOptions.map((themeOption, index) => {
           return (


### PR DESCRIPTION
Use top position and opacity properties for the transition of the drop-down menu on open. No longer using display: hidden.