### PR TITLE
Make UI more responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
       <Header />
 
       <main className="mx-auto max-w-[90rem] px-2 pt-12 md:px-4">
-        <section className="mb-8 flex items-center justify-between">
+        <section className="mb-4 flex flex-col justify-between gap-3 sm:mb-8 sm:flex-row sm:items-center">
           <InstancesAmountSelect
             amount={instancesAmount}
             setAmount={setInstancesAmount}

--- a/src/components/CommonUtils/index.tsx
+++ b/src/components/CommonUtils/index.tsx
@@ -19,7 +19,7 @@ export default function CommonUtils() {
           setOpen(!open);
         }}
       >
-        <span className="flex items-center gap-1">
+        <span className="flex items-center gap-1 text-sm sm:text-base">
           Common utilities
           <WrenchScrewdriverIcon className="h-5 w-5" />
         </span>

--- a/src/components/CommonUtils/index.tsx
+++ b/src/components/CommonUtils/index.tsx
@@ -35,7 +35,7 @@ export default function CommonUtils() {
 
       <div
         aria-hidden={!open}
-        className={`absolute right-0 z-10 flex max-w-[280px] flex-col gap-1 bg-gray-100 px-6 py-4 shadow-md outline outline-2 outline-gray-900 transition-[opacity,top] dark:bg-gray-900 dark:outline-gray-200 ${
+        className={`absolute left-0 z-10 flex max-w-[280px] flex-col gap-1 bg-gray-100 px-6 py-4 shadow-md outline outline-2 outline-gray-900 transition-[opacity,top] dark:bg-gray-900 dark:outline-gray-200 sm:left-[auto] sm:right-0 ${
           open
             ? 'top-[120%] opacity-100'
             : 'pointer-events-none top-[110%] opacity-0'

--- a/src/components/DateToEpoch/TimezoneSelect.tsx
+++ b/src/components/DateToEpoch/TimezoneSelect.tsx
@@ -48,7 +48,7 @@ export default function TimezoneSelect({
 
       <ul
         aria-hidden={!open}
-        className={`absolute top-[110%] flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
+        className={`absolute top-[110%] z-10 flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
           open
             ? 'top-[120%] opacity-100'
             : 'pointer-events-none top-[110%] opacity-0'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
         >
           <section className="flex items-center gap-2">
             <h1
-              className={`text-2xl font-bold ${
+              className={`text-lg font-bold sm:text-xl md:text-2xl ${
                 isIntersecting === false && 'text-gray-100'
               }`}
             >

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -31,7 +31,7 @@ export const InstancesAmountSelect = ({
     <div className="flex items-center gap-3">
       <label
         htmlFor="date-picker-instances-amount"
-        className="text-xl font-bold"
+        className="text-lg font-bold sm:text-xl"
       >
         Converters amount
       </label>

--- a/src/components/InstancesAmountSelect.tsx
+++ b/src/components/InstancesAmountSelect.tsx
@@ -62,7 +62,7 @@ export const InstancesAmountSelect = ({
 
         <ul
           aria-hidden={!open}
-          className={`absolute flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
+          className={`absolute z-10 flex flex-col gap-2 bg-gray-900 px-1 py-2 transition-[top,opacity] dark:bg-gray-700 ${
             open
               ? 'top-[120%] opacity-100'
               : 'pointer-events-none top-[110%] opacity-0'

--- a/src/components/ThemeButton.tsx
+++ b/src/components/ThemeButton.tsx
@@ -68,7 +68,7 @@ export default function ThemeButton() {
         }}
         className="flex items-center justify-between gap-2 rounded bg-gray-200 px-2 py-1 text-gray-900 transition-colors hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-200"
       >
-        Theme
+        <span className="hidden sm:inline">Theme</span>
         {themeOptions.find((element) => element.value === theme)?.icon}
       </button>
 


### PR DESCRIPTION
On smaller screen, make these changes:
- Reduce logo's font size.
- Hide theme button text.
- Position instances amount seclector and common utils panel vertically, reduce the margin bottom.
- Re-position common utils drop-down menu panel.